### PR TITLE
added a wrapper if xmlrpc is not installed

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -290,7 +290,7 @@ if (!function_exists('xmlrpc_encode_request')) {
   function xmlrpc_encode_request($method, $params) {
     $xml  = '<?xml version="1.0"?>';
     $xml .= '<methodCall>';
-    $xml .= '<methodName>'.$method.'</methodName>';
+    $xml .= '<methodName>'.htmlspecialchars($method).'</methodName>';
     $xml .= '<params>';
     foreach ($params as $param) {
       $xml .= '<param><value><string>'.htmlspecialchars($param).'</string></value></param>';


### PR DESCRIPTION
din't find a good doku about xmlrpc_decode() but it should work without because of the "@" escaping.
