### PR TITLE
Fix for issue #9

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -70,14 +70,11 @@ class MentionClient {
       'Content-type: application/xml'
     ));
 
-    if(@$decoded=xmlrpc_decode($response)) {
-      if(is_string($decoded))
-        return true; // pingback returns a string like "Pingback was successful" when it works
-      else
-        return false; // otherwise returns an array like array('faultCode'=>48,'faultString'=>'The pingback has already been registered')
-    } else {
-      return false;
-    }
+    if(is_array(xmlrpc_decode($response))):
+        return false;
+    elseif(is_string($response) && !empty($response)): 
+        return true;
+    endif;
   }
 
   public function sendPingbackPayload($target) {


### PR DESCRIPTION
xmlrpc_decode() return values aren't consistent across php versions. In some versions of php it will return a string; in 5.5.11 it returns null on a successful pingback response. This change fixes that issue.
