### PR TITLE
Replacing deprecated preg modifier

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -259,7 +259,10 @@ class MentionClient {
     $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $headers));
     foreach($fields as $field) {
       if(preg_match('/([^:]+): (.+)/m', $field, $match)) {
-        $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+        //$match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+        $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./', function($m) {
+          return strtoupper($m[0]);
+        }, strtolower(trim($match[1])));
         if(isset($retVal[$match[1]])) {
           $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
         } else {


### PR DESCRIPTION
The /e modifier in preg_match is deprecated for security reasons. This patch replaces it with an equivalent use of preg_replace_callback.
