### PR TITLE
2 updates to functionality and 1 bug fix

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -6,6 +6,8 @@ class MentionClient {
   private $_debugging = false;
   private static $_debugStatic = false;
 
+  private $_debug_data = '';
+
   private $_sourceURL;
   private $_sourceBody;
 
@@ -150,6 +152,15 @@ class MentionClient {
 
       if($link_header && ($endpoint=$this->_findWebmentionEndpointInHeader($link_header, $target))) {
         $this->_debug("Found webmention server in header");
+
+	if(strpos($endpoint, 'https://') !== 0 && strpos($endpoint, 'http://') !== 0 ){
+	  $this->_debug('Relative endpoint found... fixing.');
+	  $matches = array();
+	  preg_match('/(https?:\/\/[^\/]+)/i', $target, $matches);
+	  $endpoint = $matches[0] . $endpoint;
+	  $this->_debug('Corrected endpoint : '.$endpoint);
+	}
+
         $this->c('webmentionServer', $target, $endpoint);
         $this->c('supportsWebmention', $target, true);
       } else {
@@ -158,6 +169,13 @@ class MentionClient {
           $this->c('body', $target, $this->_fetchBody($target));
         }
         if($endpoint=$this->_findWebmentionEndpointInHTML($this->c('body', $target), $target)) {
+	  if(strpos($endpoint, 'https://') !== 0 && strpos($endpoint, 'http://') !== 0 ){
+	    $this->_debug('Relative endpoint found... fixing.');
+	    $matches = array();
+	    preg_match('/(https?:\/\/[^\/]+)/i', $target, $matches);
+	    $endpoint = $matches[0] . $endpoint;
+	    $this->_debug('Corrected endpoint : '.$endpoint);
+	  }
           $this->c('webmentionServer', $target, $endpoint);
           $this->c('supportsWebmention', $target, true);
         }
@@ -242,8 +260,12 @@ class MentionClient {
   }
   private function _debug($msg) {
     if($this->_debugging)
-      echo "\t" . $msg . "\n";
+      $this->_debug_data .= "\t" . $msg . "\n";
   }
+  public function getDebug(){
+      return $this->_debug_data;
+  }
+
   private static function _debug_($msg) {
     if(self::$_debugStatic)
       echo "\t" . $msg . "\n";

--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -10,6 +10,7 @@ class MentionClient {
 
   private $_sourceURL;
   private $_sourceBody;
+  private $_shortURL;
 
   private $_links = array();
 
@@ -24,9 +25,10 @@ class MentionClient {
   private $_proxy = false;
   private static $_proxyStatic = false;
   
-  public function __construct($sourceURL, $sourceBody=false, $proxyString=false) {
+  public function __construct($sourceURL, $sourceBody=false, $proxyString=false, $shortURL=false) {
     $this->setProxy($proxyString);
     $this->_sourceURL = $sourceURL;
+    $this->_shortURL = $shortURL;
     if($sourceBody)
       $this->_sourceBody = $sourceBody;
     else
@@ -222,7 +224,12 @@ class MentionClient {
     $webmentionServer = $this->c('webmentionServer', $target);
     $this->_debug("Sending to webmention server: " . $webmentionServer);
 
-    return self::sendWebmention($webmentionServer, $this->_sourceURL, $target, $vouch);
+    if($this->_shortURL && ((strpos($target,'brid.gy') !== FALSE && strpos($target,'brid.gy') < 10) ||
+    (strpos($target,'brid-gy') !== FALSE && strpos($target,'brid-gy') < 10))){
+        return self::sendWebmention($webmentionServer, $this->_shortURL, $target, $vouch);
+    } else {
+        return self::sendWebmention($webmentionServer, $this->_sourceURL, $target, $vouch);
+    }
   }
 
   public function sendSupportedMentions($vouch_class = false) {

--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -224,8 +224,8 @@ class MentionClient {
     $webmentionServer = $this->c('webmentionServer', $target);
     $this->_debug("Sending to webmention server: " . $webmentionServer);
 
-    if($this->_shortURL && ((strpos($target,'brid.gy') !== FALSE && strpos($target,'brid.gy') < 10) ||
-    (strpos($target,'brid-gy') !== FALSE && strpos($target,'brid-gy') < 10))){
+    if($this->_shortURL && ((strpos($target,'brid.gy') !== FALSE && strpos($target,'brid.gy') < 15) ||
+    (strpos($target,'brid-gy') !== FALSE && strpos($target,'brid-gy') < 15))){
         return self::sendWebmention($webmentionServer, $this->_shortURL, $target, $vouch);
     } else {
         return self::sendWebmention($webmentionServer, $this->_sourceURL, $target, $vouch);

--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -225,13 +225,13 @@ class MentionClient {
     return self::sendWebmention($webmentionServer, $this->_sourceURL, $target, $vouch);
   }
 
-  public function sendSupportedMentions($vouch_set = false) {
+  public function sendSupportedMentions($vouch_class = false) {
       $totalAccepted = 0;
 
       foreach($this->_links as $link) {
         $this->_debug("Checking $link");
-        if($vouch_set){
-            $totalAccepted += $this->sendSupportedMentionsToLink($link, $vouch_set[$link]);
+        if($vouch_class){
+            $totalAccepted += $this->sendSupportedMentionsToLink($link, $vouch_class->getPossibleVouchFor($link));
         } else {
             $totalAccepted += $this->sendSupportedMentionsToLink($link);
         }


### PR DESCRIPTION
KyleWM is using a webmention endpoint as a relative url '/webmention' which obviously was not working.  I added a bit to check if the endpoint is relative and correct it if so.

I added an ability to return the text from the debug messages by a call rather than only output to console.

I added the ability to get back any URLs returned by webmention clients.  This is very useful for brid.gy integration as I get the syndication links it returns to me.