### PR TITLE
replace call to xmlprc_decode with simple string check

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -69,24 +69,14 @@ class MentionClient {
       'Content-type: application/xml'
     ));
 
-    if($response['code'] != 200)
+    if($response['code'] != 200 || empty($response['body']))
       return false;
 
-    $body = xmlrpc_decode($response['body']);
+     // collapse whitespace just to be safe
+     $body = strtolower(preg_replace('/\s+/', '', $response['body']));
 
-    // Invalid XMLRPC response
-    if($body === null)
-      return false;
-
-    // The pingback response was not a string
-    if(!is_string($body))
-      return false;
-
-    // The response must contain a non-empty string
-    if(strlen($body) > 0)
-      return true;
-
-    return false;
+     // successful response MUST contain a single string
+     return $body && strpos($body, '<fault>') === false && strpos($body, '<string>') !== false;
   }
 
   public function sendPingback($sourceURL, $targetURL) {

--- a/tests/SendPingbackTest.php
+++ b/tests/SendPingbackTest.php
@@ -34,7 +34,7 @@ class SendPingbackTest extends PHPUnit_Framework_TestCase {
   public function testEmptyBodyResponse() {
     $endpoint = 'http://pingback-endpoint.example/empty-body';
     $response = $this->client->sendPingbackToEndpoint($endpoint, 'source', 'target');
-    $this->assertFalse($response);
+    $this->assertTrue($response);
   }
 
   public function testValidResponse() {


### PR DESCRIPTION
- strip whitespace and check for the presence of <string> and not
  <fault> to see if response are successful

- pingback empty-body test returns a string ""; it was previously
  evaluating to false, I think it should be true based on the spec
  (and changed the test as such)

fixes #22