### PR TITLE
Set CURLOPT_ENCODING

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -488,6 +488,7 @@ class MentionClient {
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_ENCODING, '');
     if (self::$_proxy) curl_setopt($ch, CURLOPT_PROXY, self::$_proxy);
     $response = curl_exec($ch);
     $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);


### PR DESCRIPTION
In certain configurations, it's possible that the response using curl comes back gzipped. And then it's impossible to find the webmention endpoint in the HTML.

Setting CURLOPT_ENCODING to nothing lets curl figure out what it can accept and then unzip if needed for instance. 

Had this problem with fed.brid.gy. Setting these lines fixed sending discovering the webmention endpoint again.