### PR TITLE
Fix implode()'s deprecated (in PHP 7.4) args order

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -221,7 +221,7 @@ class MentionClient {
 
       if(array_key_exists('Link', $headers)) {
         if(is_array($headers['Link'])) {
-          $link_header = implode($headers['Link'], ", ");
+          $link_header = implode(", ", $headers['Link']);
         } else {
           $link_header = $headers['Link'];
         }


### PR DESCRIPTION
Swap `implode()` parameters. Backwards compatible with older PHP versions, as there the arguments could be presented in either order. (See #36.)