### PR TITLE
Fixed bug with implode parameter order

### DIFF
--- a/src/IndieWeb/MentionClient.php
+++ b/src/IndieWeb/MentionClient.php
@@ -221,7 +221,7 @@ class MentionClient {
 
       if(array_key_exists('Link', $headers)) {
         if(is_array($headers['Link'])) {
-          $link_header = implode($headers['Link'], ", ");
+          $link_header = implode(", ", $headers['Link']);
         } else {
           $link_header = $headers['Link'];
         }


### PR DESCRIPTION
The use of `implode` here with the separator after the array is deprecated as of PHP 7.4, and invalid as of PHP 8. This is breaking webmentions in Known installations on those platforms, and presumably other downstream clients.

PHP reference: https://www.php.net/manual/en/function.implode.php