### PR TITLE
remove old php versions and add 7.3 and 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.2
+  - 7.3
+  - 7.4
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.6",
     "mf2/mf2": ">=0.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*"
+    "phpunit/phpunit": "^6"
   }
 }


### PR DESCRIPTION
I think it is no longer needed to test PHP < 5.6. Even WordPress requires 5.6 and recommends 7.4.